### PR TITLE
fix: set client token on token exchange

### DIFF
--- a/nordigen/nordigen.py
+++ b/nordigen/nordigen.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Final
+from typing import Dict, Final, Optional
 
 import requests
 from requests.models import HTTPError, Response
@@ -40,7 +40,7 @@ class NordigenClient:
             "Content-Type": "application/json",
             "User-Agent": "Nordigen-Python-v2",
         }
-        self._token = None
+        self._token: Optional[str] = None
         self.institution = InstitutionsApi(client=self)
         self.requisition = RequisitionsApi(client=self)
         self.agreement = AgreementsApi(client=self)
@@ -93,7 +93,8 @@ class NordigenClient:
             payload,
             self._headers,
         )
-        self._headers["Authorization"] = f"Bearer {response['access']}"
+
+        self.token = response["access"]
         return response
 
     def exchange_token(self, refresh_token: str) -> TokenType:
@@ -107,12 +108,15 @@ class NordigenClient:
             TokenType: Dict that contains access and refresh token
         """
         payload = {"refresh": refresh_token}
-        return self.request(
+        response = self.request(
             HTTPMethod.POST,
             f"{self.__ENDPOINT}/refresh/",
             payload,
             self._headers,
         )
+
+        self.token = response["access"]
+        return response
 
     def request(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,26 +28,28 @@ class TestClient(unittest.TestCase):
 
         mock_request.return_value.json.return_value = mocked_token
         response = self.client.generate_token()
-        response["access_expires"] == 86400
-        response["access"] == "access token"
-        assert (
-            mock.call(
-                url=f"{self.url}/token/new/",
-                headers=self.client._headers,
-                data=json.dumps(payload),
-            )
-            in mock_request.call_args_list
+
+        mock_request.assert_called_with(
+            url=f"{self.url}/token/new/",
+            headers=self.client._headers,
+            data=json.dumps(payload),
         )
+
+        assert response["access_expires"] == 86400
+        assert response["access"] == mocked_token["access"]
+        assert self.client.token == "access_token"
 
     @patch("requests.post")
     def test_exchange_token(self, mock_request):
         """Test token exchange."""
         mock_request.return_value.json.return_value = {
-            "access": "access_token",
+            "access": "new_access_token",
             "access_expires": 86400,
         }
+
         response = self.client.exchange_token(refresh_token="refresh_token")
-        assert response["access"] == "access_token"
+        assert self.client.token == "new_access_token"
+        assert response["access"] == "new_access_token"
 
     @patch("requests.get")
     def test_get_request(self, mock_request):


### PR DESCRIPTION
## Related Issue
The client access token does not update on token exchange.

## Proposed Changes
  * Update client token on token exchange
  * Updated tests

## Additional Info
Token exchange should (at least in my opinion 🙂) update the client token as well.
