### PR TITLE
Add response object to HTTPError

### DIFF
--- a/nordigen/nordigen.py
+++ b/nordigen/nordigen.py
@@ -166,7 +166,7 @@ class NordigenClient:
             return response.json()
 
         raise HTTPError(
-            {"response": response.json(), "status": response.status_code}
+            {"response": response.json(), "status": response.status_code}, response=response
         )
 
     def initialize_session(


### PR DESCRIPTION
## Related Issue

Trying to handle `HTTPError`s communicating with nordigen API, the response keyword argument is missing, preventing us from properly inspecting status code.

## Proposed Changes
  * Simply add the response in the `response` kwarg when instantiating the `HTTPError`

## Additional Info
Any additional information
