### PR TITLE
Timeout error correction

### DIFF
--- a/nordigen/nordigen.py
+++ b/nordigen/nordigen.py
@@ -31,7 +31,7 @@ class NordigenClient:
         self,
         secret_key: str,
         secret_id: str,
-        timeout: int = 10,
+        timeout: int = 20,
         base_url: str = "https://bankaccountdata.gocardless.com/api/v2"
     ) -> None:
         self.secret_key = secret_key


### PR DESCRIPTION
Adjusted the timeout setting from 10 to 20 seconds to accommodate calls that were failing due to timeout error. This change should help ensure more reliable execution of these calls.

Related Issue
Timeout error

Proposed Changes
Change 1: Increased the default timeout setting in the configuration from 10 seconds to 20 seconds.